### PR TITLE
updating git version from 1.8 to latest 2.12.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM centos:7
 
-RUN yum install -y wget make git hg svn bzr gcc docker && \
+RUN yum install -y wget make hg svn bzr gcc docker https://centos7.iuscommunity.org/ius-release.rpm && yum install -y git2u && \
   yum clean all
 
 ENV GOLANG_VERSION 1.7.1
@@ -29,7 +29,3 @@ ENV PATH $PATH:/go/bin
 ENV GOPATH=/go
 
 RUN go get github.com/fabric8io/gobump
-
-# installing latest version of git
-RUN yum remove -y git
-RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm && yum install -y git2u

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,7 @@ ENV PATH $PATH:/go/bin
 ENV GOPATH=/go
 
 RUN go get github.com/fabric8io/gobump
+
+# installing latest version of git
+RUN yum remove -y git
+RUN yum install -y https://centos7.iuscommunity.org/ius-release.rpm && yum install -y git2u


### PR DESCRIPTION
@rawlingsj, I need to update the git version in the go builder so that kompose tests could run on it. he tests starts failing here https://github.com/kubernetes-incubator/kompose/blob/master/script/test/cmd/tests.sh#L23 

Let me know if this is ok ?